### PR TITLE
Enable custom story templates

### DIFF
--- a/src/components/book-customization/BookCustomizationFlow.tsx
+++ b/src/components/book-customization/BookCustomizationFlow.tsx
@@ -70,9 +70,17 @@ const BookCustomizationFlow: React.FC<BookCustomizationFlowProps> = ({
                 childName={bookData.childName}
                 childAge={bookData.childAge}
                 childGender={bookData.childGender}
+                childPronouns={bookData.childPronouns}
+                conceptionMethod={bookData.conceptionMethod}
+                donorType={bookData.donorType}
+                surrogateName={bookData.surrogateName}
                 onNameChange={(value) => handleUpdateField("childName", value)}
                 onAgeChange={(value) => handleUpdateField("childAge", value)}
                 onGenderChange={(value) => handleUpdateField("childGender", value)}
+                onPronounsChange={(value) => handleUpdateField("childPronouns", value)}
+                onConceptionMethodChange={(value) => handleUpdateField("conceptionMethod", value)}
+                onDonorTypeChange={(value) => handleUpdateField("donorType", value)}
+                onSurrogateNameChange={(value) => handleUpdateField("surrogateName", value)}
               />
             )}
             {currentStep === 3 && (

--- a/src/components/book-customization/ChildDetailsStep.tsx
+++ b/src/components/book-customization/ChildDetailsStep.tsx
@@ -8,18 +8,34 @@ type ChildDetailsStepProps = {
   childName: string;
   childAge: string;
   childGender: string;
+  childPronouns: string;
+  conceptionMethod: string;
+  donorType: string;
+  surrogateName: string;
   onNameChange: (value: string) => void;
   onAgeChange: (value: string) => void;
   onGenderChange: (value: string) => void;
+  onPronounsChange: (value: string) => void;
+  onConceptionMethodChange: (value: string) => void;
+  onDonorTypeChange: (value: string) => void;
+  onSurrogateNameChange: (value: string) => void;
 };
 
 const ChildDetailsStep = ({
   childName,
   childAge,
   childGender,
+  childPronouns,
+  conceptionMethod,
+  donorType,
+  surrogateName,
   onNameChange,
   onAgeChange,
-  onGenderChange
+  onGenderChange,
+  onPronounsChange,
+  onConceptionMethodChange,
+  onDonorTypeChange,
+  onSurrogateNameChange,
 }: ChildDetailsStepProps) => {
   // Generate age options for children 0-12
   const ageOptions = Array.from({ length: 13 }, (_, i) => {
@@ -93,6 +109,58 @@ const ChildDetailsStep = ({
               </Label>
             </div>
           </RadioGroup>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="child-pronouns">Child's Pronouns</Label>
+          <Select value={childPronouns} onValueChange={onPronounsChange}>
+            <SelectTrigger id="child-pronouns">
+              <SelectValue placeholder="Select pronouns" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="she/her">she/her</SelectItem>
+              <SelectItem value="he/him">he/him</SelectItem>
+              <SelectItem value="they/them">they/them</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="conception-method">Conception Method</Label>
+          <Select value={conceptionMethod} onValueChange={onConceptionMethodChange}>
+            <SelectTrigger id="conception-method">
+              <SelectValue placeholder="Select method" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="IVF">IVF</SelectItem>
+              <SelectItem value="IUI">IUI</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="donor-type">Donor Type</Label>
+          <Select value={donorType} onValueChange={onDonorTypeChange}>
+            <SelectTrigger id="donor-type">
+              <SelectValue placeholder="Select donor" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="sperm">Sperm Donor</SelectItem>
+              <SelectItem value="egg">Egg Donor</SelectItem>
+              <SelectItem value="double">Double Donor</SelectItem>
+              <SelectItem value="none">None</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="surrogate-name">Surrogate Name (if any)</Label>
+          <Input
+            id="surrogate-name"
+            value={surrogateName}
+            onChange={(e) => onSurrogateNameChange(e.target.value)}
+            placeholder="Enter surrogate's name"
+          />
         </div>
       </div>
     </div>

--- a/src/components/book-customization/FamilyMembersStep.tsx
+++ b/src/components/book-customization/FamilyMembersStep.tsx
@@ -12,6 +12,7 @@ type FamilyMember = {
   role: string;
   name: string;
   customRole?: string;
+  pronouns?: string;
 };
 
 type FamilyMembersStepProps = {
@@ -59,38 +60,38 @@ const FamilyMembersStep = ({
       switch (familyStructure) {
         case "two-parents":
           defaultMembers.push(
-            { id: crypto.randomUUID(), role: "Mom", name: "" },
-            { id: crypto.randomUUID(), role: "Dad", name: "" }
+            { id: crypto.randomUUID(), role: "Mom", name: "", pronouns: "she/her" },
+            { id: crypto.randomUUID(), role: "Dad", name: "", pronouns: "he/him" }
           );
           break;
         case "single-mom":
-          defaultMembers.push({ id: crypto.randomUUID(), role: "Mom", name: "" });
+          defaultMembers.push({ id: crypto.randomUUID(), role: "Mom", name: "", pronouns: "she/her" });
           break;
         case "single-dad":
-          defaultMembers.push({ id: crypto.randomUUID(), role: "Dad", name: "" });
+          defaultMembers.push({ id: crypto.randomUUID(), role: "Dad", name: "", pronouns: "he/him" });
           break;
         case "two-moms":
           defaultMembers.push(
-            { id: crypto.randomUUID(), role: "Mom", name: "" },
-            { id: crypto.randomUUID(), role: "Mama", name: "" }
+            { id: crypto.randomUUID(), role: "Mom", name: "", pronouns: "she/her" },
+            { id: crypto.randomUUID(), role: "Mama", name: "", pronouns: "she/her" }
           );
           break;
         case "two-dads":
           defaultMembers.push(
-            { id: crypto.randomUUID(), role: "Dad", name: "" },
-            { id: crypto.randomUUID(), role: "Papa", name: "" }
+            { id: crypto.randomUUID(), role: "Dad", name: "", pronouns: "he/him" },
+            { id: crypto.randomUUID(), role: "Papa", name: "", pronouns: "he/him" }
           );
           break;
         case "grandparents":
           defaultMembers.push(
-            { id: crypto.randomUUID(), role: "Grandmother", name: "" },
-            { id: crypto.randomUUID(), role: "Grandfather", name: "" }
+            { id: crypto.randomUUID(), role: "Grandmother", name: "", pronouns: "she/her" },
+            { id: crypto.randomUUID(), role: "Grandfather", name: "", pronouns: "he/him" }
           );
           break;
         case "adoptive":
           defaultMembers.push(
-            { id: crypto.randomUUID(), role: "Adoptive Mom", name: "" },
-            { id: crypto.randomUUID(), role: "Adoptive Dad", name: "" }
+            { id: crypto.randomUUID(), role: "Adoptive Mom", name: "", pronouns: "she/her" },
+            { id: crypto.randomUUID(), role: "Adoptive Dad", name: "", pronouns: "he/him" }
           );
           break;
       }
@@ -104,7 +105,8 @@ const FamilyMembersStep = ({
     const newMember = {
       id: crypto.randomUUID(),
       role: "",
-      name: ""
+      name: "",
+      pronouns: ""
     };
     
     const updatedMembers = [...members, newMember];
@@ -197,6 +199,23 @@ const FamilyMembersStep = ({
                   onChange={(e) => updateMember(member.id, "name", e.target.value)}
                   placeholder="Enter name"
                 />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor={`pronouns-${member.id}`}>Pronouns</Label>
+                <Select
+                  value={member.pronouns || ''}
+                  onValueChange={(value) => updateMember(member.id, 'pronouns', value)}
+                >
+                  <SelectTrigger id={`pronouns-${member.id}`}>
+                    <SelectValue placeholder="Select pronouns" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="she/her">she/her</SelectItem>
+                    <SelectItem value="he/him">he/him</SelectItem>
+                    <SelectItem value="they/them">they/them</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
             </CardContent>
           </Card>

--- a/src/hooks/useBookData.ts
+++ b/src/hooks/useBookData.ts
@@ -7,6 +7,10 @@ const initialBookData = {
   childName: "",
   childAge: "",
   childGender: "",
+  childPronouns: "",
+  conceptionMethod: "",
+  donorType: "",
+  surrogateName: "",
   selectedIllustrations: {},
   dedication: "",
 };

--- a/src/lib/bookTemplates.ts
+++ b/src/lib/bookTemplates.ts
@@ -1,3 +1,8 @@
+export type Page = {
+  text: string;
+  illustration?: string;
+};
+
 export type BookTemplate = {
   id: string;
   name: string;
@@ -8,9 +13,65 @@ export type BookTemplate = {
   family_structure: string;
   donor_process?: string;
   art_process?: string;
+  pageDescriptors?: Page[];
+};
+
+export const OUR_SPECIAL_FAMILY_TEMPLATE: BookTemplate = {
+  id: 'our-special-family',
+  name: 'Our Special Family',
+  description: 'A customizable story celebrating diverse family creation.',
+  thumbnail_url: null,
+  pages: 16,
+  age_range: '3-7',
+  family_structure: 'various',
+  donor_process: 'various',
+  art_process: 'various',
+  pageDescriptors: [
+    {
+      text: '"{parentNames}, can you tell me again about how our family started?" asked {childName} one starry night.',
+      illustration: 'Parent(s) and child sitting together looking at a photo album',
+    },
+    {
+      text: 'For a long time, {parentPronoun} dreamed about sharing {parentPossessive} love and home with a child.',
+      illustration: 'Parent(s) daydreaming, thought bubble showing a house with a swing set',
+    },
+    {
+      text: '{parentPronounCapital} learned that families come in all sorts of wonderful shapes and sizes.',
+      illustration: 'Various family constellations',
+    },
+    {
+      text: 'Some, like ours, have {familyStructureDescription}.',
+      illustration: 'Custom family illustration',
+    },
+    {
+      text: 'With the help of kind people and doctors, we started the journey to bring you into the world.',
+      illustration: 'Doctors or helpers',
+    },
+    {
+      text: 'You grew snug and safe {whereBabyGrew}. We would sing to you and tell you stories.',
+      illustration: 'Ultrasound scene',
+    },
+    {
+      text: 'And then one magical day, you were born! Our hearts felt so full of love.',
+      illustration: 'Birth scene with happy family',
+    },
+    {
+      text: 'Since that day, we have been on so many adventures together. Each day with you is our favorite day.',
+      illustration: 'Parent(s) and toddler reading and playing',
+    },
+    {
+      text: 'There are lots of families like ours who found a special way to make their children.',
+      illustration: 'Other families with similar structure',
+    },
+    {
+      text: 'Sweet dreams, my precious {childTerm}. We love our special family more than all the stars in the sky.',
+      illustration: 'Child falling asleep with parents nearby',
+    },
+  ],
 };
 
 export const DUMMY_STORIES: BookTemplate[] = [
+  OUR_SPECIAL_FAMILY_TEMPLATE,
   {
     id: 'b7e1c2a0-1234-4cde-8f2a-abcdef123456',
     name: 'Two Moms, Sperm Donor',

--- a/src/lib/renderStory.ts
+++ b/src/lib/renderStory.ts
@@ -1,0 +1,8 @@
+export function renderStory(template: { pageDescriptors?: { text: string }[] }, bookData: Record<string, any>): string[] {
+  if (!template.pageDescriptors) return [];
+  return template.pageDescriptors.map(page =>
+    page.text.replace(/\{(\w+)\}/g, (_, key) => {
+      return key in bookData ? String(bookData[key]) : '';
+    })
+  );
+}

--- a/src/pages/CustomizeBook.tsx
+++ b/src/pages/CustomizeBook.tsx
@@ -70,10 +70,16 @@ const CustomizeBook = () => {
             'childName' in obj &&
             'childAge' in obj &&
             'childGender' in obj &&
+            'childPronouns' in obj &&
+            'conceptionMethod' in obj &&
+            'donorType' in obj &&
+            'surrogateName' in obj &&
             'selectedIllustrations' in obj &&
             'dedication' in obj;
           if (typeof data.content === 'object' && !Array.isArray(data.content) && isValidBookData(data.content)) {
-            setSelectedStory(data.content as BookTemplate);
+            setBookData(data.content);
+            const template = DUMMY_STORIES.find(t => t.id === data.template_id) || null;
+            setSelectedStory(template);
           } else {
             setSelectedStory(null);
           }
@@ -134,6 +140,10 @@ const CustomizeBook = () => {
       childName: "",
       childAge: "",
       childGender: "",
+      childPronouns: "",
+      conceptionMethod: "",
+      donorType: "",
+      surrogateName: "",
       selectedIllustrations: {},
       dedication: "",
     });

--- a/tests/renderStory.test.mjs
+++ b/tests/renderStory.test.mjs
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import { renderStory } from '../dist/lib/renderStory.js';
+const template = { pageDescriptors: [{ text: 'Hello {name}' }, { text: '{greeting} world' }] };
+const result = renderStory(template, { name: 'Alice', greeting: 'Hi' });
+assert.deepStrictEqual(result, ['Hello Alice', 'Hi world']);
+console.log('renderStory tests passed');


### PR DESCRIPTION
## Summary
- support pages content on templates and add Our Special Family template
- track new customization fields (pronouns and conception info)
- collect pronouns for family members and child
- allow editing books by loading saved data correctly
- add simple renderStory helper
- basic unit test for rendering logic

## Testing
- `npx tsc --module es2020 --target es2020 --outDir dist/lib src/lib/renderStory.ts`
- `node tests/renderStory.test.mjs`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*