### PR TITLE
Fix refresh 404 on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,10 @@
 
   ## Uncomment to use this redirect for Single Page Applications like create-react-app.
   ## Not needed for static site generators.
-  #[[redirects]]
-  #  from = "/*"
-  #  to = "/index.html"
-  #  status = 200
+  [[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200
 
   ## (optional) Settings for Netlify Dev
   ## https://github.com/netlify/cli/blob/main/docs/netlify-dev.md#project-detection


### PR DESCRIPTION
## Summary
- enable SPA routing in Netlify config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node tests/renderStory.test.mjs` *(fails: Cannot find module '/workspace/little-seedling-tales/dist/lib/renderStory.js')*